### PR TITLE
ansible_make_new_tested_role did not name the generated test with a d…

### DIFF
--- a/ansible_make_new_tested_role
+++ b/ansible_make_new_tested_role
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+default_distrib=centos6
+
 usage() {
   [ $# -gt 0 ] && echo $@ >&2
   echo "usage : $(basename $0) [-h] [-c] role_name
@@ -52,9 +54,9 @@ cd ${role_dir}/tests
 [ -f ${ansible_cfg} ] || cp ${tools}/${ansible_cfg} .
 
 
-if [ ! -f "test_${role}" ]
+if [ ! -f "test_${role}_${default_distrib}" ]
 then
-  cat << __EOF__ >test_${role}
+  cat << __EOF__ >test_${role}_${default_distrib}
 #!/bin/bash
 
 test_failed() {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -113,7 +113,7 @@ if [ $# -gt 0 ] ; then
 fi
 
 bash_unit="${inside_tests_path}/bash_unit"
-files_with_tests=$(find . | sed '/.*test_'${test_name}'.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
+files_with_tests=$(find . | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
 run_test="${bash_unit} ${tests_list} ${files_with_tests}"
 
 container_base_name=$(echo ${test_name} | tr -d "_")


### PR DESCRIPTION
…efault distrib

name. But run_test defaults to centos6 and so did not run tests at all just after
test role initialisation.