### PR TITLE
Reference `-p` option in `run_tests.sh`

### DIFF
--- a/template/tests/run_tests.sh
+++ b/template/tests/run_tests.sh
@@ -9,6 +9,7 @@ usage: $(basename $0) [-d] [-v] [-h] [test1 test2 ...]
         -d : activates debug mode
         -v : gets verbose (mainly outputs docker outputs)
         -q : query the list of managed distributions
+        -p : run tests matching a given pattern
         -h : this help
         If tests names are passed as arguments, only those will run. Default is to run all tests.
 "
@@ -22,7 +23,7 @@ start_container() {
 
   docker ps -a --format="{{.Names}}" | grep '^'${container}'$' >/dev/null 2>&1 && docker rm --force ${container} >/dev/null
   eval echo "Running docker with flags [${docker_flags}]" ${output}
-  container_id=$(docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image})
+  docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image}
 
   if grep jessie <(echo $distrib_name) >/dev/null
   then
@@ -95,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdq name
+while getopts vhdqp name
 do
   case $name in
     v)

--- a/template/tests/run_tests.sh
+++ b/template/tests/run_tests.sh
@@ -96,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdqp name
+while getopts "vhdqp:" name
 do
   case $name in
     v)
@@ -109,6 +109,9 @@ do
       echo ${managed_distribs}
       exit
       ;;
+    p)
+      list_of_patterns+=("-p $OPTARG")
+      ;;
     h)
       usage
       ;;
@@ -118,13 +121,9 @@ shift $((OPTIND-1))
 
 [ $verbose_flag -eq 0 ] && output=">/dev/null 2>&1" || output="2>&1"
 
-if [ $# -gt 0 ] ; then
-  tests_list=$(echo $@ | tr ' ' '\n' | sed 's/^/-p /' | xargs)
-fi
-
 bash_unit="${inside_tests_path}/bash_unit"
 files_with_tests=$(find . | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
-run_test="${bash_unit} ${tests_list} ${files_with_tests}"
+run_test="${bash_unit} ${list_of_patterns[@]} ${files_with_tests}"
 
 container_base_name=$(echo ${test_name} | tr -d "_")
 containers=${container_base_name}

--- a/tests/expected/new_role_deb/tests/.run_tests.sh
+++ b/tests/expected/new_role_deb/tests/.run_tests.sh
@@ -9,6 +9,7 @@ usage: $(basename $0) [-d] [-v] [-h] [test1 test2 ...]
         -d : activates debug mode
         -v : gets verbose (mainly outputs docker outputs)
         -q : query the list of managed distributions
+        -p : run tests matching a given pattern
         -h : this help
         If tests names are passed as arguments, only those will run. Default is to run all tests.
 "
@@ -22,7 +23,7 @@ start_container() {
 
   docker ps -a --format="{{.Names}}" | grep '^'${container}'$' >/dev/null 2>&1 && docker rm --force ${container} >/dev/null
   eval echo "Running docker with flags [${docker_flags}]" ${output}
-  container_id=$(docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image})
+  docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image}
 
   if grep jessie <(echo $distrib_name) >/dev/null
   then
@@ -95,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdq name
+while getopts vhdqp name
 do
   case $name in
     v)

--- a/tests/expected/new_role_deb/tests/.run_tests.sh
+++ b/tests/expected/new_role_deb/tests/.run_tests.sh
@@ -96,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdqp name
+while getopts "vhdqp:" name
 do
   case $name in
     v)
@@ -109,6 +109,9 @@ do
       echo ${managed_distribs}
       exit
       ;;
+    p)
+      list_of_patterns+=("-p $OPTARG")
+      ;;
     h)
       usage
       ;;
@@ -118,13 +121,9 @@ shift $((OPTIND-1))
 
 [ $verbose_flag -eq 0 ] && output=">/dev/null 2>&1" || output="2>&1"
 
-if [ $# -gt 0 ] ; then
-  tests_list=$(echo $@ | tr ' ' '\n' | sed 's/^/-p /' | xargs)
-fi
-
 bash_unit="${inside_tests_path}/bash_unit"
 files_with_tests=$(find . | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
-run_test="${bash_unit} ${tests_list} ${files_with_tests}"
+run_test="${bash_unit} ${list_of_patterns[@]} ${files_with_tests}"
 
 container_base_name=$(echo ${test_name} | tr -d "_")
 containers=${container_base_name}

--- a/tests/expected/new_role_deb_clu/tests/.run_tests.sh
+++ b/tests/expected/new_role_deb_clu/tests/.run_tests.sh
@@ -9,6 +9,7 @@ usage: $(basename $0) [-d] [-v] [-h] [test1 test2 ...]
         -d : activates debug mode
         -v : gets verbose (mainly outputs docker outputs)
         -q : query the list of managed distributions
+        -p : run tests matching a given pattern
         -h : this help
         If tests names are passed as arguments, only those will run. Default is to run all tests.
 "
@@ -22,7 +23,7 @@ start_container() {
 
   docker ps -a --format="{{.Names}}" | grep '^'${container}'$' >/dev/null 2>&1 && docker rm --force ${container} >/dev/null
   eval echo "Running docker with flags [${docker_flags}]" ${output}
-  container_id=$(docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image})
+  docker run -d ${docker_flags} ${docker_volumes} --name=${container} --hostname=${container} ${docker_image}
 
   if grep jessie <(echo $distrib_name) >/dev/null
   then
@@ -95,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdq name
+while getopts vhdqp name
 do
   case $name in
     v)

--- a/tests/expected/new_role_deb_clu/tests/.run_tests.sh
+++ b/tests/expected/new_role_deb_clu/tests/.run_tests.sh
@@ -96,7 +96,7 @@ inside_tests_path="${inside_roles_path}/${test_name}/tests"
 verbose_flag=0
 debug_flag=0
 
-while getopts vhdqp name
+while getopts "vhdqp:" name
 do
   case $name in
     v)
@@ -109,6 +109,9 @@ do
       echo ${managed_distribs}
       exit
       ;;
+    p)
+      list_of_patterns+=("-p $OPTARG")
+      ;;
     h)
       usage
       ;;
@@ -118,13 +121,9 @@ shift $((OPTIND-1))
 
 [ $verbose_flag -eq 0 ] && output=">/dev/null 2>&1" || output="2>&1"
 
-if [ $# -gt 0 ] ; then
-  tests_list=$(echo $@ | tr ' ' '\n' | sed 's/^/-p /' | xargs)
-fi
-
 bash_unit="${inside_tests_path}/bash_unit"
 files_with_tests=$(find . | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
-run_test="${bash_unit} ${tests_list} ${files_with_tests}"
+run_test="${bash_unit} ${list_of_patterns[@]} ${files_with_tests}"
 
 container_base_name=$(echo ${test_name} | tr -d "_")
 containers=${container_base_name}

--- a/tests/tests_4_run_tests
+++ b/tests/tests_4_run_tests
@@ -52,8 +52,16 @@ test_v_option_launches_verbose_docker() {
   assert "grep -e 'Running docker with flags' /tmp/expect.$$" "expected verbose docker output didn't come"
 }
 
+test_p_option_is_passed_to_bash_unit() {
+  ./run_tests.sh -p one_equal_to_one -p one_equal_to_two test_plumb_unit > /tmp/expect.$$ 2>&1
+
+  assert "grep one_equal_to_one /tmp/expect.$$" "one_equal_to_one has not been run"
+  assert "grep one_equal_to_two /tmp/expect.$$" "one_equal_to_two has not been run"
+  assert_fail "grep two_equal_to_two /tmp/expect.$$" "two_equal_to_two should not have run"
+}
+
 test_mounts_common_roles_in_etc_ansible_roles() {
-  assert "./run_tests.sh roles_in_etc_ansible_roles"
+  assert "./run_tests.sh -p roles_in_etc_ansible_roles test_plumb_unit"
 }
 
 test_plumb_unit_runs_all_tests_from_multiple_test_files() {
@@ -74,6 +82,7 @@ setup() {
 #!/bin/bash
 ${test_prefix}is_one_equal_to_one() { assert_equals 1 1 "oups"; }
 ${test_prefix}is_one_equal_to_two() { assert_equals 1 2 "oups"; }
+${test_prefix}is_two_equal_to_two() { assert_equals 2 2 "oups"; }
 ${test_prefix}roles_in_etc_ansible_roles() { assert "ls /etc/ansible/roles/plumb_unit"; }
 EOF
 }

--- a/tests/tests_4_run_tests
+++ b/tests/tests_4_run_tests
@@ -50,24 +50,22 @@ test_v_option_launches_verbose_docker() {
 #  assert "grep -e 'Sending build context to Docker daemon' /tmp/expect.$$" "expected verbose docker output didn't come"
 #  assert "grep -e 'Successfully built' /tmp/expect.$$" "expected verbose docker output didn't come"
   assert "grep -e 'Running docker with flags' /tmp/expect.$$" "expected verbose docker output didn't come"
-  rm /tmp/expect.$$
 }
 
 test_mounts_common_roles_in_etc_ansible_roles() {
   assert "./run_tests.sh roles_in_etc_ansible_roles"
 }
 
-test_multiple_test_files() {
+test_plumb_unit_runs_all_tests_from_multiple_test_files() {
   cat > test_plumb_unit_2_centos6 <<EOF
 #!/bin/bash
 ${test_prefix}is_one_equal_to_one() { assert_equals 1 1 "oups"; }
 EOF
-  assert "./run_tests.sh -p one_equal_to_one | wc -l > /tmp/expect.$$ 2>&1"
-  # Following expects 4 lines in the output :
-  # 2 telling which test file is played
-  # 2 for the one test in each test file
-  assert_equals "4" "$(cat /tmp/expect.$$)" "there is less than 2 tests played"
-  rm /tmp/expect.$$ test_plumb_unit_2_centos6
+
+  ./run_tests.sh > /tmp/expect.$$ 2>&1
+
+  assert "grep test_plumb_unit_2_centos6 /tmp/expect.$$"
+  assert "grep test_plumb_unit_centos6 /tmp/expect.$$"
 }
 
 setup() {
@@ -85,6 +83,7 @@ teardown() {
   rm run_tests_*.sh 2>/dev/null
   [ -L roles/plumb_unit ] && rm roles/plumb_unit
   [ -d roles ] && rmdir roles/
+  rm -f /tmp/expect.$$
 }
 
 assert "expect -v" "expect needs to be installed to run this tests"


### PR DESCRIPTION
  * used to throw an `illegal option` error despite working
  * correct tests passing for dubious reasons
  * ... and `container_id` was unused