### PR TITLE
search for tests in tests repo only

### DIFF
--- a/template/tests/run_tests.sh
+++ b/template/tests/run_tests.sh
@@ -124,7 +124,7 @@ shift $((OPTIND-1))
 [ $verbose_flag -eq 0 ] && output=">/dev/null 2>&1" || output="2>&1"
 
 bash_unit="${inside_tests_path}/bash_unit"
-files_with_tests=$(find . | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
+files_with_tests=$(find . -maxdepth 1 | sed '/.*test_.*'${distrib}${cluster}'$/!d;/~$/d' | sed "s:./:${inside_tests_path}/:g" | xargs)
 run_test="${bash_unit} ${list_of_patterns[@]} ${files_with_tests}"
 
 container_base_name=$(echo ${test_name} | tr -d "_")


### PR DESCRIPTION
When you create a file with a name starting by test in a subdirectory of the tests it is found by run_tests.sh. Even if your file is not a test file, it is treated as one and this crashes the tests. This commit resolves the problem by searching for tests file only in the directory containing run_tests.